### PR TITLE
Added email verification for non admin users

### DIFF
--- a/app/Http/Controllers/Auth/VerificationController.php
+++ b/app/Http/Controllers/Auth/VerificationController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Foundation\Auth\VerifiesEmails;
 
 class VerificationController extends Controller

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -13,7 +13,7 @@ class HomeController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware(['auth', 'verified']);
     }
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-class User extends Authenticatable
+class User extends Authenticatable implements MustVerifyEmail
 {
     use Notifiable;
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "^7.2.5|^8.0",
         "fideloper/proxy": "^4.4",
         "fruitcake/laravel-cors": "^2.0",
-        "guzzlehttp/guzzle": "^6.3.1|^7.0.1",
+        "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^7.29",
         "laravel/tinker": "^2.5",
         "laravel/ui": "^2.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b5b487c78defbb7ec78f1e632805560",
+    "content-hash": "72aa06cdf98dd7a4015a31fd9dfe2a88",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,7 +21,7 @@ Route::get('/register', function () {
     return redirect('/login');
 });
 
-Auth::routes();
+Auth::routes(['verify' => true]);
 
 Route::get('/admin', 'AdminController@index');
 Route::get('/home', 'HomeController@index')->name('home');


### PR DESCRIPTION
## Description
- This PR allows non admin users to verify their email

## Commands to run
- `php artisan config:cache`
- `php artisan config:clear`

## How to test
1. Create a user manually, make `email_verified_at` column null __(since you cannot register anymore)__
2. Edit your `.env`
```
MAIL_MAILER=smtp
MAIL_HOST=smtp.googlemail.com
MAIL_PORT=465
MAIL_USERNAME={YOUR GMAIL EMAIL}
MAIL_PASSWORD={YOUR GMAIL PASSWORD}
MAIL_ENCRYPTION=ssl
MAIL_FROM_ADDRESS=test@test.com
MAIL_FROM_NAME="${APP_NAME}"
```
3. Update your gmail account, allow lower apps to access your account
- https://medium.com/@agavitalis/how-to-send-an-email-in-laravel-using-gmail-smtp-server-53d962f01a0c
4. Login and Verify